### PR TITLE
Fix minor typo in Config.md

### DIFF
--- a/Config.md
+++ b/Config.md
@@ -65,7 +65,7 @@ For DirectX11 with `fsr21_12`, `fsr22_12` and `xess` upscaler options, OptiScale
 
 ```ini
 [Dx11withDx12]
-; Syncing meathods for Dx11 with Dx12
+; Syncing methods for Dx11 with Dx12
 ;
 ; Valid values are;
 ;	0 - No syncing                                  (fastest, most prone to errors)


### PR DESCRIPTION
## Summary
- correct a misspelling in the Dx11withDx12 section comment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68430679dec88330be176690ee26025f